### PR TITLE
Support pystac-client ItemCollections and metadata from Planetary Computer

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1267,6 +1267,21 @@ python-versions = "*"
 testing = ["nose", "coverage"]
 
 [[package]]
+name = "planetary-computer"
+version = "0.1.0"
+description = "Planetary Computer SDK for Python"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+click = ">=7.1"
+pydantic = {version = ">=1.7.3", extras = ["dotenv"]}
+pystac = ">=0.5.6,<0.6"
+pytz = ">=2020.5"
+requests = ">=2.25.1"
+
+[[package]]
 name = "ply"
 version = "3.11"
 description = "Python Lex & Yacc"
@@ -1348,6 +1363,22 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pydantic"
+version = "1.8.1"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+python-dotenv = {version = ">=0.10.4", optional = true, markers = "extra == \"dotenv\""}
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "pyflakes"
 version = "2.3.1"
 description = "passive checker of Python programs"
@@ -1413,6 +1444,22 @@ python-dateutil = ">=2.7.0"
 validation = ["jsonschema (==3.2.0)"]
 
 [[package]]
+name = "pystac-client"
+version = "0.1.1"
+description = "Python library for working with Spatiotemporal Asset Catalog (STAC)."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pystac = ">=0.5.6,<0.6.0"
+python-dateutil = ">=2.7.0"
+requests = ">=2.25.1,<2.26.0"
+
+[package.extras]
+validation = ["jsonschema (==3.2.0)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.7.5"
 description = "Extensions to the standard Python datetime module"
@@ -1422,6 +1469,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-dotenv"
+version = "0.17.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
@@ -2079,7 +2137,7 @@ docs = ["Sphinx", "numpydoc", "sphinx-autodoc-typehints", "pandoc", "nbsphinx", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "23b677891322120b33163a323886e75f72881f92764b2895137177aa9a90e92b"
+content-hash = "a1ec0feb9e08f99586539b7430d9e551bfb35ce5e4a0c645576bbc7c2bb7f028"
 
 [metadata.files]
 affine = [
@@ -2877,6 +2935,10 @@ pkginfo = [
     {file = "pkginfo-1.7.0-py2.py3-none-any.whl", hash = "sha256:9fdbea6495622e022cc72c2e5e1b735218e4ffb2a2a69cde2694a6c1f16afb75"},
     {file = "pkginfo-1.7.0.tar.gz", hash = "sha256:029a70cb45c6171c329dfc890cde0879f8c52d6f3922794796e06f577bb03db4"},
 ]
+planetary-computer = [
+    {file = "planetary-computer-0.1.0.tar.gz", hash = "sha256:a451b9dfd266d077e7a64a164b73d761f6a1d8bc5b63f413f8ceb35b33507a71"},
+    {file = "planetary_computer-0.1.0-py3-none-any.whl", hash = "sha256:c208d40072eaea9b8f10f1e34a189984d074e8d120465046b8e01e4c0bde7c02"},
+]
 ply = [
     {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
     {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
@@ -2943,6 +3005,30 @@ pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
+pydantic = [
+    {file = "pydantic-1.8.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0c40162796fc8d0aa744875b60e4dc36834db9f2a25dbf9ba9664b1915a23850"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:fff29fe54ec419338c522b908154a2efabeee4f483e48990f87e189661f31ce3"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:fbfb608febde1afd4743c6822c19060a8dbdd3eb30f98e36061ba4973308059e"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:eb8ccf12295113ce0de38f80b25f736d62f0a8d87c6b88aca645f168f9c78771"},
+    {file = "pydantic-1.8.1-cp36-cp36m-win_amd64.whl", hash = "sha256:20d42f1be7c7acc352b3d09b0cf505a9fab9deb93125061b376fbe1f06a5459f"},
+    {file = "pydantic-1.8.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:dde4ca368e82791de97c2ec019681ffb437728090c0ff0c3852708cf923e0c7d"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3bbd023c981cbe26e6e21c8d2ce78485f85c2e77f7bab5ec15b7d2a1f491918f"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:830ef1a148012b640186bf4d9789a206c56071ff38f2460a32ae67ca21880eb8"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:fb77f7a7e111db1832ae3f8f44203691e15b1fa7e5a1cb9691d4e2659aee41c4"},
+    {file = "pydantic-1.8.1-cp37-cp37m-win_amd64.whl", hash = "sha256:3bcb9d7e1f9849a6bdbd027aabb3a06414abd6068cb3b21c49427956cce5038a"},
+    {file = "pydantic-1.8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2287ebff0018eec3cc69b1d09d4b7cebf277726fa1bd96b45806283c1d808683"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:4bbc47cf7925c86a345d03b07086696ed916c7663cb76aa409edaa54546e53e2"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:6388ef4ef1435364c8cc9a8192238aed030595e873d8462447ccef2e17387125"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:dd4888b300769ecec194ca8f2699415f5f7760365ddbe243d4fd6581485fa5f0"},
+    {file = "pydantic-1.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:8fbb677e4e89c8ab3d450df7b1d9caed23f254072e8597c33279460eeae59b99"},
+    {file = "pydantic-1.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2f2736d9a996b976cfdfe52455ad27462308c9d3d0ae21a2aa8b4cd1a78f47b9"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:3114d74329873af0a0e8004627f5389f3bb27f956b965ddd3e355fe984a1789c"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:258576f2d997ee4573469633592e8b99aa13bda182fcc28e875f866016c8e07e"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c17a0b35c854049e67c68b48d55e026c84f35593c66d69b278b8b49e2484346f"},
+    {file = "pydantic-1.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:e8bc082afef97c5fd3903d05c6f7bb3a6af9fc18631b4cc9fedeb4720efb0c58"},
+    {file = "pydantic-1.8.1-py3-none-any.whl", hash = "sha256:e3f8790c47ac42549dc8b045a67b0ca371c7f66e73040d0197ce6172b385e520"},
+    {file = "pydantic-1.8.1.tar.gz", hash = "sha256:26cf3cb2e68ec6c0cfcb6293e69fb3450c5fd1ace87f46b64f678b0d29eac4c3"},
+]
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
@@ -2992,9 +3078,17 @@ pystac = [
     {file = "pystac-0.5.6-py3-none-any.whl", hash = "sha256:3dfb9068169570714276e54a80832e555a136595a4d5316e6998bcc55cc2d639"},
     {file = "pystac-0.5.6.tar.gz", hash = "sha256:ee0da32e65e93b240dcdcf68f5a16fa2f3f9e937477161f574b04fc48682e84a"},
 ]
+pystac-client = [
+    {file = "pystac-client-0.1.1.tar.gz", hash = "sha256:b39b7d318e7e1372d47336737fa19a5c6ce2c4ab2dd97153ad18c73a48e07111"},
+    {file = "pystac_client-0.1.1-py3-none-any.whl", hash = "sha256:6f02f0dc470decabad70cb65fd6b52cc524d8f2048c1858c463214cc93c1b9c8"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.7.5.tar.gz", hash = "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"},
     {file = "python_dateutil-2.7.5-py2.py3-none-any.whl", hash = "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.17.0.tar.gz", hash = "sha256:471b782da0af10da1a80341e8438fca5fadeba2881c54360d5fd8d03d03a4f4a"},
+    {file = "python_dotenv-0.17.0-py2.py3-none-any.whl", hash = "sha256:49782a97c9d641e8a09ae1d9af0856cc587c8d2474919342d5104d85be9890b2"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ snakeviz = "^2.1.0"
 sphinx-autobuild = "^2020.9.1"
 twine = "^3.4.1"
 keyring = "^23.0.1"
+pystac-client = "^0.1.1"
+planetary-computer = "^0.1.0"
 
 [tool.poetry.extras]
 docs = [

--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -283,7 +283,7 @@ def prepare_items(
                             f"- The `proj:transform` and `proj:epsg` fields set on the asset, or on the item\n"
                             f"- The `proj:shape` and one of `proj:bbox` or `bbox` fields set on the asset, "
                             "or on the item\n\n"
-                            "Please specify the `resolution=` argument to set the output resolution manually."
+                            "Please specify the `resolution=` argument to set the output resolution manually. "
                             f"(Remember that resolution must be in the units of your CRS (http://epsg.io/{out_epsg})"
                             "---not necessarily meters."
                         )

--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -380,6 +380,21 @@ def to_coords(
                     maxy + half_ypixel,
                 )
 
+            # NumPy arange produces `ceil((stop - start)/step)` elements, whereas GDAL rounds (more or less).
+            # This, combined with floating-point error, can make our coordinates off-by-one in length,
+            # so we add/remove pixels to `maxx`, `maxy` as necessary to ensure the coordinates end up the same
+            # size as the array.
+            height, width = spec.shape
+            coord_width = np.ceil((maxx - minx) / xres)
+            extra_width = coord_width - width
+            if extra_width:
+                maxx -= xres * extra_width
+
+            coord_height = np.ceil((maxy - miny) / yres)
+            extra_height = coord_height - height
+            if extra_height:
+                maxy -= yres * extra_height
+
             # Wish pandas had an RangeIndex that supported floats...
             xs = pd.Float64Index(np.arange(minx, maxx, xres))
             ys = pd.Float64Index(np.arange(maxy, miny, -yres))

--- a/stackstac/stack.py
+++ b/stackstac/stack.py
@@ -86,8 +86,10 @@ def stack(
     items:
         The STAC items to stack. Can be a plain Python list of dicts
         following the STAC JSON specification, or objects from
-        the `satstac <https://github.com/sat-utils/sat-stac>`_ (preferred) or
-        `pystac <https://github.com/stac-utils/pystac>`_ libraries.
+        the `satstac <https://github.com/sat-utils/sat-stac>`_ (preferred),
+        `pystac <https://github.com/stac-utils/pystac>`_, or
+        `pystac-client <https://github.com/stac-utils/pystac-client>`_
+         libraries.
     assets:
         Which asset IDs to use. Any Items missing a particular Asset will return an array
         of ``fill_value`` for that Asset. By default, returns all assets with a GeoTIFF


### PR DESCRIPTION
Support [pystac-client](https://github.com/stac-utils/pystac-client) ItemCollections, which is what the Planetary Computer docs are recommending over sat-search now.

Also handle rounding errors in computing the xy coordinates via `np.arange`. Because GDAL rounds and NumPy uses `ceil`, sometimes you could end up with the number of coordinates not matching the shape of the array, which xarray complains about. This happened while testing on L8C2 from AI for Earth, following along with this notebook https://planetarycomputer.microsoft.com/dataset/landsat-8-c2-l2#Example-Notebook.

FYI @TomAugspurger with this, stackstac seems to be able to work with the metadata from all of the STAC-API datasets and turn them into DataArrays. Not sure yet if they'll actually compute though, since I don't have an API key yet.