### PR TITLE
assume UTC, and drop timezone

### DIFF
--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -355,7 +355,7 @@ def to_coords(
             [item["properties"]["datetime"] for item in items],
             infer_datetime_format=True,
             errors="coerce",
-        ),
+        ).tz_convert('UTC').tz_localize(None),
         "id": xr.Variable("time", [item["id"] for item in items]),
         "band": asset_ids,
     }

--- a/stackstac/stack.py
+++ b/stackstac/stack.py
@@ -251,8 +251,9 @@ def stack(
         xarray DataArray, backed by a Dask array. No IO will happen until calling ``.compute()``,
         or accessing ``.values``. The dimensions will be ``("time", "band", "y", "x")``.
 
-        ``time`` will be equal in length to the number of items you pass in, and indexed by date. Note that this means
-        multiple entries could have the same index.
+        ``time`` will be equal in length to the number of items you pass in, and indexed by STAC Item datetime. 
+        Note that this means multiple entries could have the same index. Note also datetime strings are cast to 
+        'UTC' but passed to xarray without timezone information (dtype='datetime64[ns]').
 
         ``band`` will be equal in length to the number of asset IDs used (see the ``assets`` parameter for more).
 


### PR DESCRIPTION
simple fix for #2 

in brief, currently xarray does not like timezone information that can be present in (`pandas.DatetimeIndex(['2019-12-30 00:00:01+00:00'], dtype='datetime64[ns, UTC]', freq=None)`). As a result nicely formated datetimes are converted to nanosecond integers, causing confusion for users.

STAC datetimes *should* all be UTC. This additional line ensures the UTC timezone info is present (due to a pandas bug with infer_datetime_format=True), and then drops the timezone info for xarray. 

A few examples of what this does:
```python
# want to ensure these work
print(pd.to_datetime('2018-10-27T23:30:00Z').tz_convert('UTC').tz_localize(None))
print(pd.to_datetime('2018-10-27T23:30:00.123Z').tz_convert('UTC').tz_localize(None))

# valid ISO8601, but unclear if found in wild STACs
print(pd.to_datetime('2018-10-28T01:30:00+02:00').tz_convert('UTC').tz_localize(None))

# an invalid ISO8601 string (no Z) -> probably ok to hit errors in this case
pd.to_datetime('2018-10-28 01:30:00.1').tz_convert('UTC').tz_localize(None)
```

```pytb
2018-10-27 23:30:00
2018-10-27 23:30:00.123000
2018-10-27 23:30:00
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-21-3e456a4822cb> in <module>
      7 
      8 # an invalid ISO8601 string (no Z) -> probably ok to hit errors in this case
----> 9 pd.to_datetime('2018-10-28 01:30:00.1').tz_convert('UTC').tz_localize(None)

pandas/_libs/tslibs/timestamps.pyx in pandas._libs.tslibs.timestamps.Timestamp.tz_convert()

TypeError: Cannot convert tz-naive Timestamp, use tz_localize to localize
```
