### PR TITLE
Ignore items with missing asset metadata

### DIFF
--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -462,7 +462,10 @@ def to_coords(
             accumulate_metadata.accumulate_metadata(
                 (item["assets"].get(asset_id, {}) for item in items),
                 skip_fields={"href", "type", "roles"},
-                only_allsame=True,
+                only_allsame="ignore-missing",
+                # ^ NOTE: we `ignore-missing` because I've observed some STAC collections
+                # missing `eo:bands` on some items.
+                # xref https://github.com/sat-utils/sat-api/issues/229
             )
             for asset_id in asset_ids
         ]


### PR DESCRIPTION
When finding the asset-level metadata that all items have in common, we should not drop a field just because one item happens to be missing that field, if all the other items had the same value for it.

For example, some items have `eo:bands`, some don't: https://github.com/sat-utils/sat-api/issues/229. When computing `eo:bands` for the DataArray, just ignore the items that are missing it. Before, we were dropping `eo:bands` for the whole stack.