### PR TITLE
Handle some errors as nodata

### DIFF
--- a/stackstac/nodata_reader.py
+++ b/stackstac/nodata_reader.py
@@ -1,0 +1,75 @@
+from typing import Optional, Tuple, Type, Union, cast
+import re
+
+import numpy as np
+from rasterio.windows import Window
+
+from .reader_protocol import Reader
+
+State = Tuple[np.dtype, Optional[Union[int, float]]]
+
+
+class NodataReader:
+    "Reader that returns a constant (nodata) value for all reads"
+    scale_offset = (1.0, 0.0)
+
+    def __init__(
+        self,
+        *,
+        dtype: np.dtype,
+        fill_value: Optional[Union[int, float]] = None,
+        **kwargs,
+    ) -> None:
+        self.dtype = dtype
+        self.fill_value = fill_value
+
+    def read(self, window: Window, **kwargs) -> np.ndarray:
+        return nodata_for_window(window, self.fill_value, self.dtype)
+
+    def close(self) -> None:
+        pass
+
+    def __getstate__(self) -> State:
+        return (self.dtype, self.fill_value)
+
+    def __setstate__(self, state: State) -> None:
+        self.dtype, self.fill_value = state
+
+
+def nodata_for_window(
+    window: Window, fill_value: Optional[Union[int, float]], dtype: np.dtype
+):
+    assert (
+        fill_value is not None
+    ), "Trying to convert an exception to nodata, but `fill_value` is None"
+
+    height = cast(int, window.height)
+    width = cast(int, window.width)
+    # Argument of type "tuple[_T@attrib, _T@attrib]" cannot be assigned to parameter "shape" of type "_ShapeLike"
+    # in function "full"
+    return np.full((height, width), fill_value, dtype)
+
+
+def exception_matches(e: Exception, patterns: Tuple[Exception, ...]) -> bool:
+    """
+    Whether an exception matches one of the pattern exceptions
+
+    Parameters
+    ----------
+    e:
+        The exception to check
+    patterns:
+        Instances of an Exception type to catch, where ``str(exception_pattern)``
+        is a regex pattern to match against ``str(e)``.
+    """
+    e_type = type(e)
+    e_msg = str(e)
+    for pattern in patterns:
+        if issubclass(e_type, type(pattern)):
+            if re.match(str(pattern), e_msg):
+                return True
+    return False
+
+
+# Type assertion
+_: Type[Reader] = NodataReader

--- a/stackstac/reader_protocol.py
+++ b/stackstac/reader_protocol.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Protocol, Type, TYPE_CHECKING, TypeVar, Union
+from typing import Optional, Protocol, Tuple, Type, TYPE_CHECKING, TypeVar, Union
 
 import numpy as np
 
@@ -28,6 +28,7 @@ class Reader(Pickleable, Protocol):
 
     def __init__(
         self,
+        *,
         url: str,
         spec: RasterSpec,
         resampling: Resampling,
@@ -35,6 +36,7 @@ class Reader(Pickleable, Protocol):
         fill_value: Optional[Union[int, float]] = np.nan,
         rescale: bool = True,
         gdal_env: Optional[LayeredEnv] = None,
+        errors_as_nodata: Tuple[Exception, ...] = (),
     ) -> None:
         """
         Construct the Dataset *without* fetching any data.
@@ -58,6 +60,14 @@ class Reader(Pickleable, Protocol):
         gdal_env:
             A `~.LayeredEnv` of GDAL configuration options to use while opening
             and reading datasets. If None (default), `~.DEFAULT_GDAL_ENV` is used.
+        errors_as_nodata:
+            Exception patterns to ignore when opening datasets or reading data.
+            Exceptions matching the pattern will be logged as warnings, and just
+            produce nodata (``fill_value``).
+
+            The exception patterns should be instances of an Exception type to catch,
+            where ``str(exception_pattern)`` is a regex pattern to match against
+            ``str(raised_exception)``.
         """
         # TODO colormaps?
 
@@ -103,7 +113,7 @@ class FakeReader:
     or inherent to the dask graph.
     """
 
-    def __init__(self, url: str, spec: RasterSpec, *args, **kwargs) -> None:
+    def __init__(self, *, url: str, spec: RasterSpec, **kwargs) -> None:
         pass
         # self.url = url
         # self.spec = spec


### PR DESCRIPTION
Pass error patterns as `errors_as_nodata`, which if raised, will be printed as a warning, and whatever they were trying to load will be returned as an empty array. By default, `RasterioIOError("HTTP response code: 404")` is ignored.

The main thing I'm unsure about is the `warnings.warn`. In brief testing, it didn't reliably show up, and I'm not sure whether it would show up in distributed worker logs. However, I was also testing a URL that only intermittently failed, so I can't be sure the error was actually happening.

I'll likely merge this now, since it's still a significant improvement, but we should come back to the larger logging story. Additionally, this doesn't do anything about retries (#18).

cc @RichardScottOZ

Closes #12