### PR TITLE
Support `pystac.ItemCollection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.2 (...)
+- Support [pystac](https://github.com/stac-utils/pystac) ItemCollections
+
 ## 0.2.1 (2021-05-07)
 Support [xarray 0.18](http://xarray.pydata.org/en/stable/whats-new.html#v0-18-0-6-may-2021) and beyond, as well as looser version requirements for some other dependencies.
 

--- a/stackstac/stac_types.py
+++ b/stackstac/stac_types.py
@@ -45,6 +45,12 @@ except ImportError:
         def get_all_items(self) -> Iterator[PystacItem]:
             ...
 
+# pystac 1.0
+try:
+    from pystac import ItemCollection as PystacItemCollection
+except ImportError:
+    class PystacItemCollection:
+        features: List[PystacItem]
 
 try:
     from pystac_client import ItemCollection as PystacClientItemCollection
@@ -113,7 +119,7 @@ ItemSequence = Sequence[ItemDict]
 
 ItemIsh = Union[SatstacItem, PystacItem, ItemDict]
 ItemCollectionIsh = Union[
-    SatstacItemCollection, PystacCatalog, PystacClientItemCollection, ItemSequence
+    SatstacItemCollection, PystacCatalog, PystacClientItemCollection, PystacItemCollection, ItemSequence
 ]
 
 
@@ -153,7 +159,7 @@ def items_to_plain(items: Union[ItemCollectionIsh, ItemIsh]) -> ItemSequence:
     if isinstance(items, PystacCatalog):
         return [item.to_dict() for item in items.get_all_items()]
 
-    if isinstance(items, PystacClientItemCollection):
+    if isinstance(items, (PystacItemCollection, PystacClientItemCollection)):
         return [item.to_dict() for item in items.features]
 
     raise TypeError(f"Unrecognized STAC collection type {type(items)}: {items!r}")


### PR DESCRIPTION
https://github.com/stac-utils/pystac/pull/430 implemented `pystac.ItemCollection`, which is being removed from `pystac-client` in the next release. This PR adds similar handling for `pystac.ItemCollection`.

I haven't updated the documentation notebooks yet, since pystac and psytac-client are still in a release-candidate / beta. Once they're released I think the notebooks can be updated.