### PR TITLE
Ignore assets that don't have a `type`, if filtering by mimetype

### DIFF
--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -15,6 +15,7 @@ from typing import (
     Any,
     cast,
 )
+import warnings
 
 
 import affine
@@ -90,6 +91,18 @@ def prepare_items(
             id: [Mimetype.from_str(t) for t in types if t is not None]
             for id, types in type_strs_by_id.items()
         }
+
+        ids_without_type = [
+            id for id, mimetypes in mimetypes_by_id.items() if not mimetypes
+        ]
+        if ids_without_type:
+            warnings.warn(
+                f"You're filtering for assets that match the mimetype(s) {assets}, but since {len(ids_without_type)} "
+                f"(out of {len(type_strs_by_id)}) asset(s) have no `type` specified on any item, those will be "
+                "dropped. Consider passing a list of asset IDs instead to the `assets=` parameter.\n"
+                f"Assets with no type: {ids_without_type}",
+            )
+
         asset_ids = [
             asset_id
             for asset_id, asset_mimetypes in mimetypes_by_id.items()

--- a/stackstac/stack.py
+++ b/stackstac/stack.py
@@ -109,6 +109,7 @@ def stack(
         on others, then ``B1`` will not be included. Mimetypes structure is respected, so
         ``image/tiff`` will also match ``image/tiff; application=geotiff``; ``image`` will match
         ``image/tiff`` and ``image/jp2``, etc. See the `STAC common media types <MT>`_ for ideas.
+        Assets which don't have ``type`` specified on any item will be dropped in this case.
 
         Note: each asset's data must contain exactly one band. Multi-band assets (like an RGB GeoTIFF)
         are not yet supported.


### PR DESCRIPTION
Closes #70

@TomAugspurger we could certainly add inference in the future, but for now I didn't want to add the complexity. Stackstac requires plenty of other metadata that goes beyond the basic STAC required fields (geolocation / the `proj` extension, etc.), so I feel okay about requiring this too in the case where you're specifying assets by mimetype.

I'm expecting this is a rare case, so encouraging users to explicitly specify asset IDs in this case feels okay instead of automatically doing something we can't be sure is correct. We can reconsider depending on how often it comes up.

cc @scottyhq 