### PR TITLE
Nit: remove default args from Reader protocol

### DIFF
--- a/stackstac/reader_protocol.py
+++ b/stackstac/reader_protocol.py
@@ -33,9 +33,9 @@ class Reader(Pickleable, Protocol):
         spec: RasterSpec,
         resampling: Resampling,
         dtype: np.dtype,
-        fill_value: Optional[Union[int, float]] = np.nan,
-        rescale: bool = True,
-        gdal_env: Optional[LayeredEnv] = None,
+        fill_value: Optional[Union[int, float]],
+        rescale: bool,
+        gdal_env: Optional[LayeredEnv],
         errors_as_nodata: Tuple[Exception, ...] = (),
     ) -> None:
         """


### PR DESCRIPTION
Having default values on the protocol was validly throwing a type error, since AutoParallelRioReader doesn't have default values