### PR TITLE
Fix bug in accumulate_metadata() for lists of repeating values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.2 (...)
 - Support [pystac](https://github.com/stac-utils/pystac) ItemCollections
+- Fix accumulate_metadata bug for lists of repeating values
 
 ## 0.2.1 (2021-05-07)
 Support [xarray 0.18](http://xarray.pydata.org/en/stable/whats-new.html#v0-18-0-6-may-2021) and beyond, as well as looser version requirements for some other dependencies.

--- a/stackstac/accumulate_metadata.py
+++ b/stackstac/accumulate_metadata.py
@@ -90,7 +90,7 @@ def accumulate_metadata(
                     # start a new list collecting them, including Nones at the front
                     # for however many items were missing the field.
                     all_fields[existing_field] = _ourlist(
-                        [value] * (i - 1) + [existing_value, value]
+                        [existing_value] * (i - 1) + [existing_value, value]
                     )
 
         if fields is True:

--- a/stackstac/accumulate_metadata.py
+++ b/stackstac/accumulate_metadata.py
@@ -63,8 +63,9 @@ def accumulate_metadata(
     """
     if isinstance(fields, str):
         fields = (fields,)
-
+    
     all_fields: Dict[str, Any] = {}
+    
     i = 0
     for i, item in enumerate(items):
         for existing_field in all_fields.keys():
@@ -89,7 +90,7 @@ def accumulate_metadata(
                     # start a new list collecting them, including Nones at the front
                     # for however many items were missing the field.
                     all_fields[existing_field] = _ourlist(
-                        [None] * (i - 1) + [existing_value, value]
+                        [value] * (i - 1) + [existing_value, value]
                     )
 
         if fields is True:
@@ -147,8 +148,13 @@ def dict_to_coords(metadata: Dict[str, Any], dim_name: str) -> Dict[str, xr.Vari
             except TypeError:
                 # if it's not set-able, just give up
                 break
-
-        props_arr = np.squeeze(np.array(props))
+                
+        # Avoid DeprecationWarning: (list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes)
+        if isinstance(props, _ourlist) and isinstance(props[0], (list,tuple)):
+            props_arr = np.squeeze(np.array(props, dtype='object'))
+        else:
+            props_arr = np.squeeze(np.array(props))
+        
         if (
             props_arr.ndim > 1
             or props_arr.ndim == 1


### PR DESCRIPTION
Closes #78 

1. metadata sequences like `['a', 'a', 'b', 'a', ...]` were being set in xarray coordinates as `[None, None, 'b', 'a', ...]`
2. also fixes DeprecationWarning arising when STAC metadata field contains lists of values. [For example](https://github.com/relativeorbit/aws-rtc-12SYJ/blob/0038d4fd11bb0c363a6cf0f49a801ae97d2d106b/sentinel1-rtc-aws/12SYJ/2021/S1A_20210105_12SYJ_DSC/S1A_20210105_12SYJ_DSC.json#L43-L46):

```
    "sentinel:product_ids": [
      "S1A_IW_GRDH_1SDV_20210105T130950_20210105T131015_036003_0437D1_6979",
      "S1A_IW_GRDH_1SDV_20210105T131015_20210105T131040_036003_0437D1_A833"
    ],
```
becomes an array of lists. in the xarray coordinates and apparently needs an explicit `dtype='object'`

Note that you can see the behavior of 1. currently by slightly modifying the readme example to different dates so that you start with two repeating s2a acquistions`['sentinel-2a', 'sentinel-2a', 'sentinel-2b', ...]` 
