### PR TITLE
Fix `accumulate_metadata` replacing coordinates with Nones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.2 (...)
 - Support [pystac](https://github.com/stac-utils/pystac) ItemCollections
+- Fix bug where repeated metadata values would be None
 
 ## 0.2.1 (2021-05-07)
 Support [xarray 0.18](http://xarray.pydata.org/en/stable/whats-new.html#v0-18-0-6-may-2021) and beyond, as well as looser version requirements for some other dependencies.

--- a/stackstac/accumulate_metadata.py
+++ b/stackstac/accumulate_metadata.py
@@ -164,7 +164,20 @@ def dict_to_coords(
                 # if it's not set-able, just give up
                 break
 
-        props_arr = np.squeeze(np.array(props))
+        props_arr = np.squeeze(
+            np.array(
+                props,
+                # Avoid DeprecationWarning creating ragged arrays when elements are lists/tuples of different lengths
+                dtype="object"
+                if (
+                    isinstance(props, _ourlist)
+                    and len(set(len(x) for x in props if isinstance(x, (list, tuple))))
+                    > 1
+                )
+                else None,
+            )
+        )
+
         if (
             props_arr.ndim > 1
             or props_arr.ndim == 1

--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -475,13 +475,9 @@ def to_coords(
 
     if band_coords:
         flattened_metadata_by_asset = [
-            accumulate_metadata.accumulate_metadata(
+            accumulate_metadata.accumulate_metadata_only_allsame(
                 (item["assets"].get(asset_id, {}) for item in items),
                 skip_fields={"href", "type", "roles"},
-                only_allsame="ignore-missing",
-                # ^ NOTE: we `ignore-missing` because I've observed some STAC collections
-                # missing `eo:bands` on some items.
-                # xref https://github.com/sat-utils/sat-api/issues/229
             )
             for asset_id in asset_ids
         ]
@@ -512,7 +508,7 @@ def to_coords(
                 # skip_fields={"href", "title", "description", "type", "roles"},
             )
         )
-        if any(d for d in eo_by_asset):
+        if any(eo_by_asset):
             coords.update(
                 accumulate_metadata.metadata_to_coords(
                     eo_by_asset,


### PR DESCRIPTION
Fixes https://github.com/gjoseph92/stackstac/issues/78

While reviewing https://github.com/gjoseph92/stackstac/pull/87, I realized there were many things wrong with `accumulate_metadata`. The function just had too many cases and was trying to do too many things. https://github.com/gjoseph92/stackstac/pull/40 allowed for some incorrect code paths which we aren't actually using, but would be annoying to handle correctly. So instead, I basically redid https://github.com/gjoseph92/stackstac/pull/40, splitting `accumulate_metadata` into one function for the normal properties case, and one for the asset-metadata case where we only care about fields that have the same value everywhere.

@scottyhq I believe this fixes your example, but would be good to confirm:
<img width="1182" alt="Screen Shot 2021-11-14 at 1 17 15 AM" src="https://user-images.githubusercontent.com/3309802/141673811-4f3ee835-661b-482f-88a5-25d20d2a241a.png">
