### PR TITLE
Make `ipywidgets` and `scipy` properly optional

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -342,7 +342,7 @@ pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.8"
+version = "2.0.9"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -2035,7 +2035,7 @@ name = "scipy"
 version = "1.6.1"
 description = "SciPy: Scientific Library for Python"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -2552,14 +2552,14 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-binder = ["Bottleneck", "coiled", "distributed", "geogif", "ipyleaflet", "jupyterlab-geojson", "jupyter-server-proxy", "jupyterlab-system-monitor", "matplotlib", "planetary-computer", "pystac-client", "sat-search"]
+binder = ["Bottleneck", "coiled", "distributed", "geogif", "ipyleaflet", "ipywidgets", "jupyterlab-geojson", "jupyter-server-proxy", "jupyterlab-system-monitor", "matplotlib", "planetary-computer", "pystac-client", "sat-search"]
 docs = ["furo", "ipyleaflet", "ipython", "jupyter-sphinx", "nbsphinx", "numpydoc", "pandoc", "sphinx-autodoc-typehints", "Sphinx"]
-viz = ["aiohttp", "cachetools", "distributed", "ipyleaflet", "jupyter-server-proxy", "matplotlib", "mercantile", "Pillow"]
+viz = ["aiohttp", "cachetools", "distributed", "ipyleaflet", "jupyter-server-proxy", "matplotlib", "mercantile", "Pillow", "scipy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0dc583bce28b72f8f8287607a0f5708234dd43315ad91d142e1887a4ed443bde"
+content-hash = "71f491254249e618ff16f589915d0922c5dafb0d25637a06f08b8bec8ca5d693"
 
 [metadata.files]
 affine = [
@@ -2825,8 +2825,8 @@ cffi = [
     {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.8.tar.gz", hash = "sha256:735e240d9a8506778cd7a453d97e817e536bb1fc29f4f6961ce297b9c7a917b0"},
-    {file = "charset_normalizer-2.0.8-py3-none-any.whl", hash = "sha256:83fcdeb225499d6344c8f7f34684c2981270beacc32ede2e669e94f7fa544405"},
+    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
+    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pystac-client = {version = "^0.3", optional = true}
 python = "^3.8"
 rasterio = "^1.2.3"
 sat-search = {version = "^0.3.0", optional = true}
-scipy = "^1.6.1"
+scipy = {version = "^1.6.1", optional = true}
 sphinx-autodoc-typehints = {version = "^1.11.1", optional = true}
 xarray = ">=0.18,<1"
 
@@ -66,7 +66,7 @@ binder = [
   "distributed",
   "geogif",
   "ipyleaflet",
-  "ipywidets",
+  "ipywidgets",
   "jupyterlab-geojson",
   "jupyter-server-proxy",
   "jupyterlab-system-monitor",
@@ -95,6 +95,7 @@ viz = [
   "matplotlib",
   "mercantile",
   "Pillow",
+  "scipy",
 ]
 
 [build-system]


### PR DESCRIPTION
Typo on `ipywidgets` was causing the whole jupyter stack to get installed for the base stackstac installation!

Scipy is only needed for `reproject_array`, which isn't in the core API IMO. And xarray already raises a decent error when it's missing.