### PR TITLE
Relax NumPy requirement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2559,7 +2559,7 @@ viz = ["aiohttp", "cachetools", "distributed", "ipyleaflet", "jupyter-server-pro
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "71f491254249e618ff16f589915d0922c5dafb0d25637a06f08b8bec8ca5d693"
+content-hash = "052718622fd814274948455946790e0f6942f50bec30101b86f1e29d3259ade2"
 
 [metadata.files]
 affine = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ jupyterlab-system-monitor = {version = "^0.8.0", optional = true}
 matplotlib = {version = "^3.4.1", optional = true}
 mercantile = {version = "^1.1.6", optional = true}
 nbsphinx = {version = "^0.8.2", optional = true}
-numpy = "^1.20.0"
 numpydoc = {version = "^1.1.0", optional = true}
 pandoc = {version = "^1.0.2", optional = true}
 planetary-computer = {version = ">= 0.4.3, < 1", optional = true}


### PR DESCRIPTION
Didn't do an extremely thorough check, but reading the NumPy release notes for 1.20.0, it doesn't look like we actually need it. Looking at our direct NumPy usage, it all seems very basic. So I'll let NumPy come in as a transitive dependency through dask for now.

Closes #83

cc @scottyhq 