### PR TITLE
Update base URL regex to make show with paths with 'notebook' in them

### DIFF
--- a/stackstac/show.py
+++ b/stackstac/show.py
@@ -629,7 +629,7 @@ class MapObserver:
     def base_url_from_window_location(url: str) -> Optional[str]:
         if not url:
             return None
-        if path_re := re.match(r"(^.+)\/(?:lab|notebook|voila)", url):
+        if path_re := re.match(r"(^.+?)\/(?:lab|notebook|voila)", url):
             return path_re.group(1)
         return None
 


### PR DESCRIPTION
This PR updates the regex used by the `base_url_from_window_location` function. This function tries to determine the base URL of the Jupyter server, but previously failed if the path to the current notebook included `notebook` (or `lab` or `voila`). This PR changes the regex to be a 'lazy' or 'non-greedy' regex which means it will match the first occurrence of `notebook`/`lab`/etc rather than the last - and therefore extract the correct base URL.