### PR TITLE
Catch some mosaic usage errors with `nodata=nan`

### DIFF
--- a/stackstac/ops.py
+++ b/stackstac/ops.py
@@ -50,6 +50,11 @@ def mosaic(
     xarray.DataArray:
         The mosaicked `~xarray.DataArray`.
     """
+    if np.isnan(nodata) and arr.dtype.kind in "biu":
+        # Try to catch usage errors forgetting to set `nodata=`
+        raise ValueError(
+            f"Cannot use {nodata=} when mosaicing a {arr.dtype} array, since {nodata} cannot exist in the array."
+        )
     return arr.reduce(
         _mosaic,
         dim=dim,

--- a/stackstac/ops.py
+++ b/stackstac/ops.py
@@ -45,6 +45,11 @@ def mosaic(
     nodata:
         The value to treat as invalid. Default: NaN.
 
+        To catch common mis-use, raises a ``ValueError`` if ``nodata=nan``
+        is used when the array has an integer or boolean dtype. Since NaN
+        cannot exist in those arrays, this indicates a different ``nodata``
+        value needs to be used.
+
     Returns
     -------
     xarray.DataArray:


### PR DESCRIPTION
If you've specified `dtype=int` to `stackstac.stack`, this is an easy way to catch that you need to use a custom nodata value.

cc @TomAugspurger 