### PR TITLE
Pandas compat

### DIFF
--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -410,8 +410,9 @@ def to_coords(
 
         height, width = spec.shape
         # Wish pandas had an RangeIndex that supported floats...
-        xs = pd.Float64Index(np.linspace(minx, maxx, width, endpoint=False))
-        ys = pd.Float64Index(np.linspace(maxy, miny, height, endpoint=False))
+        # https://github.com/pandas-dev/pandas/issues/46484
+        xs = pd.Index(np.linspace(minx, maxx, width, endpoint=False), dtype="float64")
+        ys = pd.Index(np.linspace(maxy, miny, height, endpoint=False), dtype="float64")
 
         coords["x"] = xs
         coords["y"] = ys


### PR DESCRIPTION
pandas has deprecated using the Float64Index constructor directly, in favor of Index(..., dtype="float64").

I also opened https://github.com/pandas-dev/pandas/issues/46484, to track support for a version of RangeIndex that can support floats.