### PR TITLE
Constrain rasterio to 1.2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ planetary-computer = {version = ">= 0.4.3, < 1", optional = true}
 pyproj = "^3.0.0"
 pystac-client = {version = "^0.3", optional = true}
 python = "^3.8"
-rasterio = "^1.2.3"
+rasterio = "~1.2.3"
 sat-search = {version = "^0.3.0", optional = true}
 scipy = {version = "^1.6.1", optional = true}
 sphinx-autodoc-typehints = {version = "^1.11.1", optional = true}


### PR DESCRIPTION
As discussed here: https://github.com/gjoseph92/stackstac/pull/155