### PR TITLE
Use poetry lockfile in docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,12 +3,13 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
-# https://github.com/readthedocs/readthedocs.org/issues/4912#issuecomment-664002569
-python:
-  version: 3.8
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - viz
+# https://github.com/readthedocs/readthedocs.org/issues/4912#issuecomment-1143587902
+build:
+  os: ubuntu-20.04
+  tools:
+    python: '3.8'
+  jobs:
+    post_install:
+      - pip install poetry==1.1.13
+      - poetry config virtualenvs.create false
+      - poetry install --no-dev -E docs -E viz


### PR DESCRIPTION
Previously, we were just pip-installing the requirements and getting whatever transitive dependencies. This allowed https://github.com/gjoseph92/stackstac/issues/151 to happen.