### PR TITLE
Remove deprecated `skip_equivalent` pyproj arg

### DIFF
--- a/stackstac/geom_utils.py
+++ b/stackstac/geom_utils.py
@@ -27,9 +27,7 @@ def bounds_from_affine(
     ys = [ul_y, ll_y, lr_y, ur_y]
 
     if from_epsg != to_epsg:
-        transformer = cached_transformer(
-            from_epsg, to_epsg, skip_equivalent=True, always_xy=True
-        )
+        transformer = cached_transformer(from_epsg, to_epsg, always_xy=True)
         # TODO handle error
         xs_proj, ys_proj = transformer.transform(xs, ys, errcheck=True)
     else:
@@ -50,9 +48,7 @@ def reproject_bounds(bounds: Bbox, from_epsg: int, to_epsg: int) -> Bbox:
     # read this in pairs, downward by column
     xs = [minx, minx, maxx, maxx]
     ys = [maxy, miny, miny, maxy]
-    transformer = cached_transformer(
-        from_epsg, to_epsg, skip_equivalent=True, always_xy=True
-    )
+    transformer = cached_transformer(from_epsg, to_epsg, always_xy=True)
     xs_proj, ys_proj = transformer.transform(xs, ys, errcheck=True)  # TODO handle error
     return min(xs_proj), min(ys_proj), max(xs_proj), max(ys_proj)
 
@@ -288,9 +284,7 @@ def reproject_array(
     # We do this by, for each point in the output grid, generating
     # the coordinates in the _input_ CRS that correspond to that point.
 
-    reverse_transformer = cached_transformer(
-        spec.epsg, from_epsg, skip_equivalent=True, always_xy=True
-    )
+    reverse_transformer = cached_transformer(spec.epsg, from_epsg, always_xy=True)
 
     xs, ys = np.meshgrid(x, y, copy=False)
     src_xs, src_ys = reverse_transformer.transform(xs, ys, errcheck=True)

--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -279,7 +279,7 @@ def prepare_items(
                         )
 
                         transformer = geom_utils.cached_transformer(
-                            asset_epsg, out_epsg, skip_equivalent=True, always_xy=True
+                            asset_epsg, out_epsg, always_xy=True
                         )
                         out_px_corner_xs, out_px_corner_ys = transformer.transform(
                             px_corner_xs, px_corner_ys, errcheck=True


### PR DESCRIPTION
Closes https://github.com/gjoseph92/stackstac/issues/173

Caused by https://github.com/pyproj4/pyproj/pull/1077.

FYI @snowman2 since https://github.com/pyproj4/pyproj/pull/824 used a `DeprecationWarning`, not a `FutureWarning`, the warning would not have typically been displayed to users. That's probably why neither I nor anybody else noticed it.

> https://docs.python.org/3/library/warnings.html#warning-categories
> Class | Description
> -- | --
> DeprecationWarning | Base category for warnings about deprecated features when those warnings are intended for other Python developers (ignored by default, unless triggered by code in __main__).
> FutureWarning | Base category for warnings about deprecated features when those warnings are intended for end users of applications that are written in Python.