### PR TITLE
Fix scale and offset application when only one is available.

### DIFF
--- a/stackstac/rio_reader.py
+++ b/stackstac/rio_reader.py
@@ -402,9 +402,9 @@ class AutoParallelRioReader:
         if self.rescale:
             scale, offset = reader.scale_offset
             if scale != 1:
-                result = result * scale
+                result *= scale
             if offset != 0:
-                result = result + offset
+                result += offset
 
         result = result.astype(self.dtype, copy=False)
         result = np.ma.filled(result, fill_value=self.fill_value)

--- a/stackstac/rio_reader.py
+++ b/stackstac/rio_reader.py
@@ -401,9 +401,10 @@ class AutoParallelRioReader:
 
         if self.rescale:
             scale, offset = reader.scale_offset
-            if scale != 1 and offset != 0:
-                result *= scale
-                result += offset
+            if scale != 1:
+                result = result * scale
+            if offset != 0:
+                result = result + offset
 
         result = result.astype(self.dtype, copy=False)
         result = np.ma.filled(result, fill_value=self.fill_value)


### PR DESCRIPTION
I noted this issue recently when working with several datasets which have `scales=(0.0001,)` but `offsets=(0.0,)` resulting in the default `rescale=True` not applying the scale value.

To facilitate future testing of `rio_reader` functionality, I'd also propose incorporating some file based integration tests similar to those used in `rioxarray` which might cover these types of edge cases.