### PR TITLE
Get scale offset from item asset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {text = "MIT"}
 name = "stackstac"
 readme = "README.md"
 requires-python = ">=3.8,<4.0"
-version = "0.4.3"
+version = "0.4.4"
 
 [project.urls]
 homepage = "https://stackstac.readthedocs.io/en/latest/index.html"

--- a/stackstac/rio_reader.py
+++ b/stackstac/rio_reader.py
@@ -401,6 +401,9 @@ class AutoParallelRioReader:
 
             raise RuntimeError(msg) from e
 
+        if result.dtype != self.dtype:
+            result = result.astype(self.dtype, copy=False)
+
         if self.rescale:
             scale, offset = self.scale_offset
 
@@ -412,7 +415,6 @@ class AutoParallelRioReader:
             if offset != 0:
                 result += offset
 
-        result = result.astype(self.dtype, copy=False)
         result = np.ma.filled(result, fill_value=self.fill_value)
         return result
 

--- a/stackstac/rio_reader.py
+++ b/stackstac/rio_reader.py
@@ -304,6 +304,7 @@ class AutoParallelRioReader:
         dtype: np.dtype,
         fill_value: Union[int, float],
         rescale: bool,
+        scale_offset: Tuple[float, float],
         gdal_env: Optional[LayeredEnv] = None,
         errors_as_nodata: Tuple[Exception, ...] = (),
     ) -> None:
@@ -312,6 +313,7 @@ class AutoParallelRioReader:
         self.resampling = resampling
         self.dtype = dtype
         self.rescale = rescale
+        self.scale_offset = scale_offset
         self.fill_value = fill_value
         self.gdal_env = gdal_env or DEFAULT_GDAL_ENV
         self.errors_as_nodata = errors_as_nodata
@@ -400,7 +402,11 @@ class AutoParallelRioReader:
             raise RuntimeError(msg) from e
 
         if self.rescale:
-            scale, offset = reader.scale_offset
+            scale, offset = self.scale_offset
+
+            if np.isnan(scale) and np.isnan(offset):
+                scale, offset = reader.scale_offset
+
             if scale != 1:
                 result *= scale
             if offset != 0:

--- a/stackstac/to_dask.py
+++ b/stackstac/to_dask.py
@@ -132,6 +132,7 @@ def asset_table_to_reader_and_window(
         if url:
             asset_bounds: Bbox = asset_entry["bounds"]
             asset_window = windows.from_bounds(*asset_bounds, spec.transform)
+            asset_scale_offset = asset_entry["scale_offset"]
 
             entry: ReaderTableEntry = (
                 reader(
@@ -141,6 +142,7 @@ def asset_table_to_reader_and_window(
                     dtype=dtype,
                     fill_value=fill_value,
                     rescale=rescale,
+                    scale_offset=asset_scale_offset,
                     gdal_env=gdal_env,
                     errors_as_nodata=errors_as_nodata,
                 ),


### PR DESCRIPTION
This MR aims to enable users to specify `rescale=True` in `stackstac.stack` and have the `scale` and `offset` be obtained from the STAC metadata with priority over the COG. 