### PR TITLE
Explicitly pass dtype during dataset read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.4 (2023-06-21)
 - Resolve compatibility with NumPy >= 1.24.0 [@gjoseph92](https://github.com/gjoseph92)
 - Fix TypeError when no items overlap with the given `bounds` [@gjoseph92](https://github.com/gjoseph92)
+- Fix scale and offset application when only one is available [@sharkinspatial](https://github.com/sharkinsspatial)
 - Change timer logging to DEBUG level [@jorge-cervest](https://github.com/jorge-cervest)
 
 ## 0.4.3 (2022-09-14)

--- a/stackstac/rio_reader.py
+++ b/stackstac/rio_reader.py
@@ -323,9 +323,7 @@ class AutoParallelRioReader:
         with self.gdal_env.open:
             with time(f"Initial read for {self.url!r} on {_curthread()}: {{t}}"):
                 try:
-                    ds = SelfCleaningDatasetReader(
-                        self.url, sharing=False
-                    )
+                    ds = SelfCleaningDatasetReader(self.url, sharing=False)
                 except Exception as e:
                     msg = f"Error opening {self.url!r}: {e!r}"
                     if exception_matches(e, self.errors_as_nodata):
@@ -386,6 +384,7 @@ class AutoParallelRioReader:
         try:
             result = reader.read(
                 window=window,
+                out_dtype=self.dtype,
                 masked=True,
                 # ^ NOTE: we always do a masked array, so we can safely apply scales and offsets
                 # without potentially altering pixels that should have been the ``fill_value``
@@ -406,8 +405,10 @@ class AutoParallelRioReader:
             if offset != 0:
                 result += offset
 
-        result = result.astype(self.dtype, copy=False)
         result = np.ma.filled(result, fill_value=self.fill_value)
+        assert np.issubdtype(result.dtype, self.dtype), (
+            f"Expected result array with dtype {self.dtype!r}, got {result.dtype!r}"
+        )
         return result
 
     def close(self) -> None:


### PR DESCRIPTION
We weren't asking rasterio for arrays of the output dtype, so we'd just get whatever the native dtype was of the GeoTIFF. If the GeoTIFF was an integer dtype, but specified floating-point scale/offset, then applying the scaling would fail. This basically moves the cast-to-output-dtype _before_ applying scaling, so whatever you pass for `dtype=` (float64 by default) will actually control it.

Closes https://github.com/gjoseph92/stackstac/issues/206