### PR TITLE
Remove deprecated argument

### DIFF
--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -380,7 +380,6 @@ def to_coords(
 
     times = pd.to_datetime(
         [item["properties"]["datetime"] for item in items],
-        infer_datetime_format=True,
         errors="coerce",
     )
     if times.tz is not None:


### PR DESCRIPTION
Removing the deprecated argument 'infer_datetime_format'. This is the deprecation warning by Pandas:
> stackstac\stackstac\prepare.py:369: UserWarning: The argument 'infer_datetime_format' is deprecated and will be removed in a future version. A strict version of it is now the default, see https://pandas.pydata.org/pdeps/0004-consistent-to-datetime-parsing.html. You can safely remove this argument.
> times = pd.to_datetime(