### PR TITLE
supporting multidimensional coordinnates

### DIFF
--- a/stackstac/accumulate_metadata.py
+++ b/stackstac/accumulate_metadata.py
@@ -1,196 +1,37 @@
-from typing import (
-    Container,
-    Dict,
-    Hashable,
-    Iterable,
-    Literal,
-    Mapping,
-    Sequence,
-    Union,
-    TypeVar,
-)
-
-import numpy as np
-import xarray as xr
-
-
-# properties can contain lists; need some way to tell them a singleton list
-# apart from the list of properties we're collecting
-class _ourlist(list):
-    pass
-
-
-def metadata_to_coords(
-    items: Iterable[Mapping[str, object]],
-    dim_name: str,
-    fields: Union[str, Sequence[str], Literal[True]] = True,
-    skip_fields: Container[str] = (),
-) -> Dict[str, xr.Variable]:
-    return dict_to_coords(
-        accumulate_metadata(
-            items,
-            fields=[fields] if isinstance(fields, str) else fields,
-            skip_fields=skip_fields,
-        ),
-        dim_name,
-    )
-
-
-T = TypeVar("T", bound=Hashable)
-
-
-def accumulate_metadata(
-    items: Iterable[Mapping[T, object]],
-    fields: Union[Sequence[T], Literal[True]] = True,
-    skip_fields: Container[T] = (),
-) -> Dict[T, object]:
+def select_unique_vars(ds, dim=["band", "time"]):
     """
-    Accumulate a sequence of multiple similar dicts into a single dict of lists.
-
-    Each field will contain a list of all the values for that field (equal length to ``items``).
-    For items where the field didn't exist, None is used.
-
-    Fields with only one unique value are flattened down to just that single value.
+    Return the deduplicated data variables from a xarray.Dataset
+    that are constant along specified dimensions.
 
     Parameters
     ----------
-    items:
-        Iterable of dicts to accumulate
-    fields:
-        Only use these fields. If True, use all fields.
-    skip_fields:
-        Skip these fields.
+    ds:
+        xarray.dataset
+    dim:
+        Name of the dimension(s) to drop duplicates along
     """
-    all_fields: Dict[T, object] = {}
-    for i, item in enumerate(items):
-        # Inductive case: update existing fields
-        for existing_field, existing_value in all_fields.items():
-            new_value = item.get(existing_field, None)
-            if new_value == existing_value:
-                # leave fields that are the same for every item as singletons
-                continue
-            if isinstance(existing_value, _ourlist):
-                # we already have a list going; add to it
-                existing_value.append(new_value)
-            else:
-                # all prior values were the same; this is the first different one
-                all_fields[existing_field] = _ourlist(
-                    [existing_value] * i + [new_value]
-                )
+    dim = [dim] if type(dim) is str else dim
+    sel_dim = {i: 0 for i in dim}
+    constant_vars = ds.apply(lambda x: (x == x.isel(sel_dim)).all()).to_array()
+    constant_vars = constant_vars[constant_vars]["variable"].data
+    if len(constant_vars) > 0:
+        constant_ds = ds[constant_vars]
+        constant_ds = constant_ds.apply(lambda x: x.isel(sel_dim))  # Keeping the first value only
+    else:
+        constant_ds = {}
 
-        # Base case 1: add any never-before-seen fields, when inferring field names
-        if fields is True:
-            for new_field in item.keys() - all_fields.keys():
-                if new_field in skip_fields:
-                    continue
-                value = item[new_field]
-                all_fields[new_field] = (
-                    value if i == 0 else _ourlist([None] * i + [value])
-                )
-        # Base case 2: initialize with predefined fields
-        elif i == 0:
-            all_fields.update(
-                (field, item.get(field, None))
-                for field in fields
-                if field not in skip_fields
-            )
-
-    return all_fields
+    return constant_ds
 
 
-def accumulate_metadata_only_allsame(
-    items: Iterable[Mapping[T, object]],
-    skip_fields: Container[T] = (),
-) -> Dict[T, object]:
+def drop_allnull_vars(ds):
     """
-    Accumulate multiple similar dicts into a single flattened dict of only consistent values.
-
-    If the value of a field differs between items, the field is dropped.
-    If the value of a field is the same for all items that contain that field, the field is kept.
-
-    Note this means that missing fields are ignored, not treated as different.
+    Dropping data variable in a xarray.Dataset that are always nulls
 
     Parameters
     ----------
-    items:
-        Iterable of dicts to accumulate
-    skip_fields:
-        Skip these fields when ``fields`` is True.
+    ds:
+        xarray.dataset
     """
-    all_fields: Dict[T, object] = {}
-    for item in items:
-        for field, value in item.items():
-            if field in skip_fields:
-                continue
-            if field not in all_fields:
-                all_fields[field] = value
-            else:
-                if value != all_fields[field]:
-                    all_fields[field] = None
-
-    return {field: value for field, value in all_fields.items() if value is not None}
-
-
-def dict_to_coords(
-    metadata: Dict[str, object], dim_name: str
-) -> Dict[str, xr.Variable]:
-    """
-    Convert the output of `accumulate_metadata` into a dict of xarray Variables.
-
-    1-length lists and scalar values become 0D variables.
-
-    Instances of ``_ourlist`` become 1D variables for ``dim_name``.
-
-    Any other things with >= 1 dimension are dropped, because they probably don't line up
-    with the other dimensions of the final array.
-    """
-    coords = {}
-    for field, props in metadata.items():
-        while isinstance(props, list) and not isinstance(props, _ourlist):
-            # a list scalar (like `instruments = ['OLI', 'TIRS']`).
-
-            # first, unpack (arbitrarily-nested) 1-element lists.
-            # keep re-checking if it's still a list
-            if len(props) == 1:
-                props = props[0]
-                continue
-
-            # for now, treat multi-item lists as a set so xarray can interpret them as 0D variables.
-            # (numpy very much does not like to create object arrays containing python lists;
-            # `set` is basically a hack to make a 0D ndarray containing a Python object with multiple items.)
-            try:
-                props = set(props)
-            except TypeError:
-                # if it's not set-able, just give up
-                break
-
-        props_arr = np.squeeze(
-            np.array(
-                props,
-                # Avoid DeprecationWarning creating ragged arrays when elements are lists/tuples of different lengths
-                dtype="object"
-                if (
-                    isinstance(props, _ourlist)
-                    and len(set(len(x) if isinstance(x, (list, tuple)) else type(x) for x in props))
-                    > 1
-                )
-                else None,
-            )
-        )
-
-        if (
-            props_arr.ndim > 1
-            or props_arr.ndim == 1
-            and not isinstance(props, _ourlist)
-        ):
-            # probably a list-of-lists situation. the other dims likely don't correspond to
-            # our "bands", "y", and "x" dimensions, and xarray won't let us use unrelated
-            # dimensions. so just skip it for now.
-            continue
-
-        coords[field] = xr.Variable(
-            (dim_name,) if props_arr.ndim == 1 else (),
-            props_arr,
-        )
-
-    return coords
+    nulls = ds.isnull().all().to_array()
+    no_nulls = nulls[~nulls]["variable"]
+    return ds[no_nulls.data]

--- a/stackstac/prepare.py
+++ b/stackstac/prepare.py
@@ -396,6 +396,7 @@ def to_coords(
         "time": times,
         "id": xr.Variable("time", [item["id"] for item in items]),
         "band": asset_ids,
+        "epsg": spec.epsg
     }
 
     if xy_coords is not False:
@@ -436,100 +437,50 @@ def to_coords(
         coords["y"] = ys
 
     if properties:
-        coords.update(
-            accumulate_metadata.metadata_to_coords(
-                (item["properties"] for item in items),
-                "time",
-                fields=properties,
-                skip_fields={"datetime"},
-                # skip_fields={"datetime", "providers"},
-            )
-        )
+        # Converting to xarray dataset
+        properties = {time: item["properties"] for time, item in zip(times, items)}
+        properties_df = pd.DataFrame.from_dict(properties, orient="index")
+        properties_df.index = properties_df.index.set_names(["time"])
+        properties_ds = xr.Dataset.from_dataframe(properties_df)
 
-        # Property-merging code using awkward array. Slightly shorter, not sure if it's faster,
-        # probably not worth the dependency
+        properties_ds = accumulate_metadata.drop_allnull_vars(properties_ds)
 
-        #     import awkward as ak
-
-        #     awk_props = ak.Array([item._data for item in items]).properties
-        #     for field, props in zip(ak.fields(awk_props), ak.unzip(awk_props)):
-        #         if field == "datetime":
-        #             continue
-
-        #         # if all values are the same, collapse to a 0D coordinate
-        #         try:
-        #             if len(ak.run_lengths(props)) == 1:
-        #                 props = ak.to_list(props[0])
-        #                 # ^ NOTE: `to_list` because `ak.to_numpy` on string scalars (`ak.CharBehavior`)
-        #                 # turns them into an int array of the characters!
-        #         except NotImplementedError:
-        #             # generally because it's an OptionArray (so there's >1 value anyway)
-        #             pass
-
-        #         try:
-        #             props = np.squeeze(ak.to_numpy(props))
-        #         except ValueError:
-        #             continue
-
-        #         coords[field] = xr.Variable(
-        #             (("time",) + tuple(f"dim_{i}" for i in range(1, props.ndim)))
-        #             if np.ndim(props) > 0
-        #             else (),
-        #             props,
-        #         )
-        # else:
-        #     # For now don't use awkward when the field names are already known,
-        #     # mostly so users don't have to have it installed.
-        #     if isinstance(properties, str):
-        #         properties = (properties,)
-        #     for prop in properties:  # type: ignore (`properties` cannot be True at this point)
-        #         coords[prop] = xr.Variable(
-        #             "time", [item["properties"].get(prop) for item in items]
-        #         )
+        # Selecting properties coords that are constant
+        constant_properties_ds = accumulate_metadata.select_unique_vars(properties_ds, dim=["time"])
+        properties_ds = properties_ds.drop_vars(constant_properties_ds.keys())
 
     if band_coords:
-        flattened_metadata_by_asset = [
-            accumulate_metadata.accumulate_metadata_only_allsame(
-                (item["assets"].get(asset_id, {}) for item in items),
-                skip_fields={"href", "type", "roles"},
-            )
-            for asset_id in asset_ids
-        ]
+        # Converting to xarray dataset
+        assets = {(time, k): v for time, item in zip(times, items) for k, v in item["assets"].items() if k in asset_ids}
+        assets_df = pd.DataFrame.from_dict(assets, orient="index")
+        assets_df.index = assets_df.index.set_names(["time", "band"])
+        assets_ds = xr.Dataset.from_dataframe(assets_df)
 
-        eo_by_asset = []
-        for meta in flattened_metadata_by_asset:
-            # NOTE: we look for `eo:bands` in each Asset's metadata, not as an Item-level list.
-            # This only became available in STAC 1.0.0-beta.1, so we'll fail on older collections.
-            # See https://github.com/radiantearth/stac-spec/tree/master/extensions/eo#item-fields
-            eo = meta.pop("eo:bands", {})
-            if isinstance(eo, list):
-                eo = eo[0] if len(eo) == 1 else {}
-                # ^ `eo:bands` should be a list when present, but >1 item means it's probably a multi-band asset,
-                # which we can't currently handle, so we ignore it. we don't error here, because
-                # as long as you don't actually _use_ that asset, everything will be fine. we could
-                # warn, but that would probably just get annoying.
-            eo_by_asset.append(eo)
-            try:
-                meta["polarization"] = meta.pop("sar:polarizations")
-            except KeyError:
-                pass
+        assets_ds = accumulate_metadata.drop_allnull_vars(assets_ds)
 
-        coords.update(
-            accumulate_metadata.metadata_to_coords(
-                flattened_metadata_by_asset,
-                "band",
-                skip_fields={"href"},
-                # skip_fields={"href", "title", "description", "type", "roles"},
-            )
-        )
-        if any(eo_by_asset):
-            coords.update(
-                accumulate_metadata.metadata_to_coords(
-                    eo_by_asset,
-                    "band",
-                    fields=["common_name", "center_wavelength", "full_width_half_max"],
-                )
-            )
+        # Selecting assets coords that are constant
+        constant_assets_ds = accumulate_metadata.select_unique_vars(assets_ds, dim=["time", "band"])
+        assets_ds = assets_ds.drop_vars(constant_assets_ds.keys())
+
+        # 'band' dependant assets coords
+        band_assets_ds = accumulate_metadata.select_unique_vars(assets_ds, dim=["time"])
+        assets_ds = assets_ds.drop_vars(band_assets_ds.keys())
+
+    else:
+        constant_assets_ds = {}
+        band_assets_ds = {}
+        assets_ds = {}
+
+    # Combining into 'coords_ds' to get a global view
+    coords_ds = xr.merge([
+        constant_assets_ds,
+        band_assets_ds,
+        assets_ds,  # leftovers - time and band dependant assets coords
+        constant_properties_ds,
+        properties_ds,  # leftovers - time dependant properties coords
+    ])
+
+    coords.update({var: coords_ds[var] for var in coords_ds.drop(["time", "band"])})
 
     # Add `epsg` last in case it's also a field in properties; our data model assumes it's a coordinate
     coords["epsg"] = spec.epsg


### PR DESCRIPTION
In the cases where item assets had unique metadata per time and band, example: k1 coeficient for landsat 8 L1 data (there are a ton more usecases though), we would not get these coords in the xarray datarray (it'd get buggy - I can provide examples).

I've ran the tests, tried it on landsat 8 and sentinel 2 images, this seems stable.

I'm happy to make more changes into this, add examples etc. but would have wanted to have your opinion on it before spending more effort into this.