### PR TITLE
Fix `Unexpected shape` error with `errors_as_nodata`

### DIFF
--- a/stackstac/nodata_reader.py
+++ b/stackstac/nodata_reader.py
@@ -9,8 +9,11 @@ from .reader_protocol import Reader
 State = Tuple[np.dtype, Union[int, float]]
 
 
+# NOTE: this really should be a `ThreadsafeRioDataset` in `rio_reader.py`,
+# not a `Reader` (it's never used as one).
 class NodataReader:
     "Reader that returns a constant (nodata) value for all reads"
+
     scale_offset = (1.0, 0.0)
 
     def __init__(


### PR DESCRIPTION
Opted not to refactor `NodataReader` as described in comments because https://github.com/gjoseph92/stackstac/pull/232 removes it all together, and I don't need even more merge conflicts someday.

Fixes https://github.com/gjoseph92/stackstac/issues/243